### PR TITLE
Update out of date test dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/joshuaferrara/node-sgp4",
   "devDependencies": {
-    "mocha": "^2.2.5",
+    "mocha": "5.2.0",
     "expect.js": "*"
   }
 }


### PR DESCRIPTION
NPM keeps giving me grief whenever I install sgp4 due to
`found 3 vulnerabilities (1 low, 1 high, 1 critical)`
This just updates mocha to the newest version.

Test plan:
reran unit tests:
`802 passing (394ms)`